### PR TITLE
FE43 added check before save that current email and new email must be…

### DIFF
--- a/frontend/src/components/PopupEmail.jsx
+++ b/frontend/src/components/PopupEmail.jsx
@@ -29,6 +29,13 @@ export default function PUEmail() {
     if (!isValid) {
       return;
     }
+    
+    if (oldEmail === newEmail) {
+      setNewEmailError("New email must be different from your current email.");
+      return;
+    } else {
+      setNewEmailError("");
+    }
 
     setIsSaving(true);
 


### PR DESCRIPTION
The error message under the new email input field should be "New email must be different from your current email." if old email === new email.