### PR TITLE
Completed the password popup implementation

### DIFF
--- a/frontend/src/components/Popup.css
+++ b/frontend/src/components/Popup.css
@@ -10,7 +10,7 @@
 }
 
 .popup {
-  min-width: 550px;
+  min-width: 600px;
   background: #441E6D;
   border-radius: 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);

--- a/frontend/src/components/PopupEmail.css
+++ b/frontend/src/components/PopupEmail.css
@@ -53,7 +53,7 @@
   height: 220px;
 }
 
-.single-input-block {
+.single-input-block-email {
   height: 100px;
 }
 

--- a/frontend/src/components/PopupEmail.jsx
+++ b/frontend/src/components/PopupEmail.jsx
@@ -84,7 +84,7 @@ export default function PUEmail() {
       <Popup open={open} onClose={handleClose} title="Change Email" fail_msg={emailFail} className="popup-email">
         <div style={{ display: "flex", gap: 8 }}>
           <div className="email-input-container">
-            <div className="single-input-block"><h2>Enter your current email</h2>
+            <div className="single-input-block-email"><h2>Enter your current email</h2>
               <div style={{ display: "flex", gap: 8 }}>
                 <input
                   className="input-email"
@@ -99,7 +99,7 @@ export default function PUEmail() {
               {oldEmailError ? <p className="error-msg">{oldEmailError}</p> : ""}
             </div>
 
-            <div className="single-input-block"><h2>Enter your new email</h2>
+            <div className="single-input-block-email"><h2>Enter your new email</h2>
               <div style={{ display: "flex", gap: 8 }}>
                 <input
                   className="input-email"

--- a/frontend/src/components/PopupPassword.css
+++ b/frontend/src/components/PopupPassword.css
@@ -47,3 +47,23 @@
   border-color: #2563eb;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
 }
+
+.popup-pwd {
+  height: 320px;
+}
+
+.single-input-block-pwd {
+  height: 100px;
+}
+
+.pwd-input-container {
+  flex: 1;
+  width: 300px;
+}
+
+.pwd-save-container {
+  flex: 0 0 auto;
+  height: 300px;
+  display: flex;  
+  align-items: center;  
+}

--- a/frontend/src/components/PopupPassword.jsx
+++ b/frontend/src/components/PopupPassword.jsx
@@ -4,6 +4,97 @@ import Popup from "./Popup"
 
 export default function PUPassword() {
   const [open, setOpen] = useState(false);
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [cfmPassword, setCfmPassword] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [oldPasswordError, setOldPasswordError] = useState("");
+  const [newPasswordError, setNewPasswordError] = useState("");
+  const [cfmPasswordError, setCfmPasswordError] = useState("");
+  const [passwordFail, setFail] = useState("");
+  async function handleSave() {
+    setFail("");
+    let isValid = true;
+    if (oldPassword == "") {
+      setOldPasswordError("This field cannot be empty");
+      isValid = false;
+    } else {
+      setOldPasswordError("");
+    }
+    const passRegex = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/
+    if (newPassword == "" || !passRegex.test(newPassword)) {
+      setNewPasswordError("Password must include at least one letter, one number, and minimum 8 letters");
+      isValid = false;
+    } else {
+      setNewPasswordError("");
+    }
+    if (cfmPassword === "" || !passRegex.test(cfmPassword)) {
+      setCfmPasswordError("Password must include at least one letter, one number, and minimum 8 letters");
+      isValid = false;
+    } else {
+      setCfmPasswordError("");
+    }
+
+    if (!isValid) {
+      return;
+    }
+    
+    if (oldPassword === newPassword) {
+      setNewPasswordError("New password must be different from your current password.");
+      isValid = false;
+    } else {
+      setNewPasswordError("");
+    }
+    if (newPassword != cfmPassword) {
+      setCfmPasswordError("This field must match your new password");
+      isValid = false;
+    } else {
+      setCfmPasswordError("");
+    }
+
+    if (!isValid) {
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const res = await fetch("/api/user/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
+      });
+
+      if (!res.ok) {
+        // backend might return JSON error { message: "..." }
+        setFail(`Save failed. Please try again later. (${res.status})`);
+        let msg = "";
+        try {
+          const data = await res.json();
+          if (data?.message) msg = data.message;
+        } catch {}
+        throw new Error(msg);
+      }
+
+      handleClose();
+    } catch (e) {
+      // setFail(e instanceof Error ? e.message : "Save failed.");
+      setFail(`Save failed. Please try again later. (${e.message})`);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+  function handleClose() {
+    setOldPassword("");
+    setNewPassword("");
+    setCfmPassword("");
+    setIsSaving(false);
+    setOpen(false);
+    setOldPasswordError("");
+    setNewPasswordError("");
+    setCfmPasswordError("");
+    setFail("");
+  };
 
   return (
     <div className="element-pwd">
@@ -11,24 +102,69 @@ export default function PUPassword() {
         Change Password
       </button>
 
-      <Popup open={open} onClose={() => setOpen(false)} title="Change Password">
-        <h2>Enter your old password</h2>
-    
-        <div style={{ display: "flex" }}>
-            <input className="input-pwd" placeholder="Type here..." />
+      <Popup open={open} onClose={handleClose} title="Change Password" fail_msg={passwordFail} className="popup-pwd">
+        <div style={{ display: "flex", gap: 8 }}>
+          <div className="pwd-input-container">
+            <div className="single-input-block-pwd">
+              <h2>Enter your current password</h2>
+              <div style={{ display: "flex", gap: 8 }}>
+                <input
+                  className="input-pwd"
+                  placeholder="Type here..."
+                  value={oldPassword}
+                  onChange={(e) => setOldPassword(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSave();
+                  }}
+                />
+              </div>
+              {oldPasswordError ? <p className="error-msg">{oldPasswordError}</p> : ""}
+            </div>
+
+            <div className="single-input-block-pwd">
+              <h2>Enter your new password</h2>
+              <div style={{ display: "flex", gap: 8 }}>
+                <input
+                  className="input-pwd"
+                  placeholder="Type here..."
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSave();
+                  }}
+                />
+              </div>
+              {newPasswordError ? <p className="error-msg">{newPasswordError}</p> : ""}
+            </div>
+
+            <div className="single-input-block-pwd">
+              <h2>Confirm your new password</h2>
+              <div style={{ display: "flex", gap: 8 }}>
+                <input
+                  className="input-pwd"
+                  placeholder="Type here..."
+                  value={cfmPassword}
+                  onChange={(e) => setCfmPassword(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSave();
+                  }}
+                />
+              </div>
+              {cfmPasswordError ? <p className="error-msg">{cfmPasswordError}</p> : ""}
+            </div>
+          </div>
+
+          <div className="pwd-save-container">
+            <button
+              className="btn-pwd btn-pwd-save"
+              onClick={handleSave}
+              disabled={isSaving}
+              type="button"
+            >
+              {isSaving ? "Saving..." : "Save"}
+            </button>
+          </div>
         </div>
-        <h2>Enter your new password</h2>
-        <div style={{ display: "flex" }}>
-            <input className="input-pwd" placeholder="Type here..." />
-        </div>
-        <h2>Confirm your new password</h2>
-        <div style={{ display: "flex" }}>
-            <input className="input-pwd" placeholder="Type here..." />
-        </div>
-        <div style={{ display: "flex" }}>
-            <button className="btn-pwd btn-pwd-save">Save</button>
-        </div>
-        
       </Popup>
     </div>
   );


### PR DESCRIPTION
Current password cannot be empty. Else display "This field cannot be empty"
New password must pass the strength test. Else display "Password must include at least one letter, one number, and minimum 8 letters"
Confirm password must pass the strength test. Else display "Password must include at least one letter, one number, and minimum 8 letters"

New password must be distinct from current password. Else display "New password must be different from your current password."
Confirm password must be identical from new password. Else display "This field must match your new password"

When save fails, display "Fail to save" in popup footer

There should not be resizing when messages are displayed. 

Popup closes when clicking cancel, clicking outside the popup, press esc.

On close, all input fields and messages should be cleared.

When saved successfully, the popup should be closed. (cannot be tested before the backend is up)